### PR TITLE
Fix fetch hooks dependencies

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default function Dashboard() {
     }
 
     fetchResumes()
-  }, [router, supabase, toast])
+  }, [router, supabase])
 
   const handleDelete = async (id: string) => {
     if (!confirm('Are you sure you want to delete this resume?')) return

--- a/app/interview/[id]/page.tsx
+++ b/app/interview/[id]/page.tsx
@@ -84,7 +84,7 @@ export default function InterviewPage({ params }: { params: { id: string } }) {
     }
 
     fetchResumeAndGenerateQuestions()
-  }, [params.id, router, supabase, toast])
+  }, [params.id, router, supabase])
 
   const handleSubmitAnswer = async () => {
     if (!interviewState.currentAnswer.trim()) {

--- a/app/resume/[id]/page.tsx
+++ b/app/resume/[id]/page.tsx
@@ -43,7 +43,7 @@ export default function ResumePage({ params }: { params: { id: string } }) {
     }
 
     fetchResume()
-  }, [params.id, router, supabase, toast])
+  }, [params.id, router, supabase])
 
   const handleOptimize = async () => {
     if (!resume?.content) {


### PR DESCRIPTION
## Summary
- remove `toast` from useEffect dependencies to avoid refetching lists when toast state changes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fce35b5448333a78831485d703222