### PR TITLE
Fix Gemini API key lookup

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default function Dashboard() {
     }
 
     fetchResumes()
-  }, [router, supabase, toast])
+  }, [router, supabase])
 
   const handleDelete = async (id: string) => {
     if (!confirm('Are you sure you want to delete this resume?')) return

--- a/app/interview/[id]/page.tsx
+++ b/app/interview/[id]/page.tsx
@@ -84,7 +84,7 @@ export default function InterviewPage({ params }: { params: { id: string } }) {
     }
 
     fetchResumeAndGenerateQuestions()
-  }, [params.id, router, supabase, toast])
+  }, [params.id, router, supabase])
 
   const handleSubmitAnswer = async () => {
     if (!interviewState.currentAnswer.trim()) {

--- a/app/resume/[id]/page.tsx
+++ b/app/resume/[id]/page.tsx
@@ -43,7 +43,7 @@ export default function ResumePage({ params }: { params: { id: string } }) {
     }
 
     fetchResume()
-  }, [params.id, router, supabase, toast])
+  }, [params.id, router, supabase])
 
   const handleOptimize = async () => {
     if (!resume?.content) {

--- a/lib/gemini.ts
+++ b/lib/gemini.ts
@@ -1,11 +1,16 @@
 // lib/gemini.ts
-import { GoogleGenerativeAI, GenerativeModel } from "@google/generative-ai";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 
 export async function generateText(prompt: string): Promise<string> {
-    const apiKey = process.env.GEMINI_API_KEY;
+    const apiKey =
+        process.env.GEMINI_API_KEY ||
+        process.env.GOOGLE_API_KEY ||
+        process.env.GOOGLE_AI_API_KEY;
     
     if (!apiKey) {
-        console.error('GEMINI_API_KEY is not set in environment variables');
+        console.error(
+            'Gemini API key is not set. Please define GEMINI_API_KEY or GOOGLE_API_KEY.'
+        );
         throw new Error('GEMINI_API_KEY is not configured');
     }
 


### PR DESCRIPTION
## Summary
- support multiple env var names for Gemini API key

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fce35b5448333a78831485d703222